### PR TITLE
Fix #2 for Premiere exits after 5 seconds

### DIFF
--- a/resources/lib/youtube_plugin/youtube/helper/video_info.py
+++ b/resources/lib/youtube_plugin/youtube/helper/video_info.py
@@ -1204,7 +1204,7 @@ class VideoInfo(object):
 
             data[mime][i]['quality_label'] = str(stream_map.get('qualityLabel'))
 
-            data[mime][i]['bandwidth'] = stream_map.get('bitrate')
+            data[mime][i]['bandwidth'] = stream_map.get('bitrate', 0)
 
             # map frame rates to a more common representation to lessen the chance of double refresh changes
             # sometimes 30 fps is 30 fps, more commonly it is 29.97 fps (same for all mapped frame rates)


### PR DESCRIPTION
Patch #2 for Issue #773 (Premiere exits after 5 seconds).

Ensure stream 'Bandwith' property is always set to a value. Default to 0 instead of NoneType